### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0+4] - December 13, 2022
+
+* Automated dependency updates
+
+
 ## [1.0.0+3] - December 6, 2022
 
 * Automated dependency updates
@@ -31,6 +36,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/client/pubspec.yaml
+++ b/example/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'client'
 description: 'A new Flutter project.'
 publish_to: 'none'
-version: '1.0.0+3'
+version: '1.0.0+4'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'
@@ -10,7 +10,7 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^1.1.6'
-  rest_client: '^2.2.0+3'
+  rest_client: '^2.2.0+4'
 
 dev_dependencies: 
   flutter_test: 

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,20 +1,20 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+1'
+version: '1.0.0+2'
 publish_to: 'none'
 
-environment:
+environment: 
   sdk: '>=2.18.0 <3.0.0'
 
-dependencies:
+dependencies: 
   args: '^2.3.1'
-  dynamic_service:
+  dynamic_service: 
     path: '../../'
   shelf_cors_headers: '^0.1.4'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.3.2'
   dependency_validator: '^3.2.2'
   functions_framework_builder: '^0.4.7'
-  test: '^1.22.0'
+  test: '^1.22.1'
   test_process: '^2.0.3'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.0+3'
+version: '1.0.0+4'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'
@@ -13,25 +13,25 @@ dependencies:
   http: '^0.13.5'
   intl: '^0.17.0'
   jose: '^0.3.3'
-  json_class: '^2.1.2+13'
+  json_class: '^2.1.2+14'
   json_path: '^0.4.2'
   json_schema2: '^2.0.2+18'
   latlong2: '^0.8.1'
   logging: '^1.1.0'
   meta: '^1.7.0'
   mime: '^1.0.3'
-  rest_client: '^2.2.0+3'
+  rest_client: '^2.2.0+4'
   shelf: '^1.4.0'
-  template_expressions: '^2.0.0+2'
+  template_expressions: '^2.0.0+3'
   uuid: '^3.0.7'
   x509: '^0.2.2'
-  yaon: '^1.0.1+7'
+  yaon: '^1.0.1+8'
 
 dev_dependencies: 
   args: '^2.3.1'
   build_runner: '^2.3.2'
   dependency_validator: '^3.2.2'
-  test: '^1.22.0'
+  test: '^1.22.1'
   test_process: '^2.0.3'
 
 false_secrets: 


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.2+13 --> 2.1.2+14
  * `rest_client`: 2.2.0+3 --> 2.2.0+4
  * `template_expressions`: 2.0.0+2 --> 2.0.0+3
  * `yaon`: 1.0.1+7 --> 1.0.1+8

dev_dependencies:
  * `test`: 1.22.0 --> 1.22.1


Analysis Successful


dependencies:
  * `rest_client`: 2.2.0+3 --> 2.2.0+4


Analysis Successful


dev_dependencies:
  * `test`: 1.22.0 --> 1.22.1


Analysis Successful

