### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0+8] - January 17, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.0+7] - January 3, 2023
 
 * Automated dependency updates
@@ -51,6 +56,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/client/pubspec.yaml
+++ b/example/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'client'
 description: 'A new Flutter project.'
 publish_to: 'none'
-version: '1.0.0+6'
+version: '1.0.0+7'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'
@@ -10,7 +10,7 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^1.1.6'
-  rest_client: '^2.2.0+6'
+  rest_client: '^2.2.0+7'
 
 dev_dependencies: 
   flutter_test: 

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+3'
+version: '1.0.0+4'
 publish_to: 'none'
 
 environment: 
@@ -16,5 +16,5 @@ dev_dependencies:
   build_runner: '^2.3.3'
   dependency_validator: '^3.2.2'
   functions_framework_builder: '^0.4.7'
-  test: '^1.22.1'
+  test: '^1.22.2'
   test_process: '^2.0.3'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.0+7'
+version: '1.0.0+8'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'
@@ -13,25 +13,25 @@ dependencies:
   http: '^0.13.5'
   intl: '^0.18.0'
   jose: '^0.3.3'
-  json_class: '^2.1.4'
+  json_class: '^2.1.4+1'
   json_path: '^0.4.2'
-  json_schema2: '^2.0.2+19'
+  json_schema2: '^2.0.2+20'
   latlong2: '^0.8.1'
   logging: '^1.1.0'
   meta: '^1.7.0'
-  mime: '^1.0.3'
-  rest_client: '^2.2.0+6'
+  mime: '^1.0.4'
+  rest_client: '^2.2.0+7'
   shelf: '^1.4.0'
-  template_expressions: '^2.2.0+1'
+  template_expressions: '^2.2.0+2'
   uuid: '^3.0.7'
   x509: '^0.2.3'
-  yaon: '^1.0.1+8'
+  yaon: '^1.0.1+9'
 
 dev_dependencies: 
   args: '^2.3.1'
   build_runner: '^2.3.3'
   dependency_validator: '^3.2.2'
-  test: '^1.22.1'
+  test: '^1.22.2'
   test_process: '^2.0.3'
 
 false_secrets: 


### PR DESCRIPTION
PR created automatically via: https://github.com/peiffer-innovations/actions-dart-dependency-updater


dependencies:
  * `json_class`: 2.1.4 --> 2.1.4+1
  * `json_schema2`: 2.0.2+19 --> 2.0.2+20
  * `mime`: 1.0.3 --> 1.0.4
  * `rest_client`: 2.2.0+6 --> 2.2.0+7
  * `template_expressions`: 2.2.0+1 --> 2.2.0+2
  * `yaon`: 1.0.1+8 --> 1.0.1+9

dev_dependencies:
  * `test`: 1.22.1 --> 1.22.2


Analysis Successful


dependencies:
  * `rest_client`: 2.2.0+6 --> 2.2.0+7


Analysis Successful


dev_dependencies:
  * `test`: 1.22.1 --> 1.22.2


Analysis Successful

