### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.1+1] - January 31, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.1] - January 24th, 2023
 
 * Dart 2.19
@@ -66,6 +71,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/client/pubspec.yaml
+++ b/example/client/pubspec.yaml
@@ -1,21 +1,21 @@
 name: 'client'
 description: 'A new Flutter project.'
 publish_to: 'none'
-version: '1.0.0+8'
+version: '1.0.0+9'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
-  flutter:
+dependencies: 
+  flutter: 
     sdk: 'flutter'
   flutter_svg: '^1.1.6'
-  rest_client: '^2.2.0+8'
+  rest_client: '^2.2.1+1'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
   flutter_lints: '^2.0.1'
 
-flutter:
+flutter: 
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,43 +1,43 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.1'
+version: '1.0.1+1'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
+dependencies: 
   collection: '^1.16.0'
   crypto: '^3.0.1'
   encrypt: '^5.0.1'
   http: '^0.13.5'
   intl: '^0.18.0'
   jose: '^0.3.3'
-  json_class: '^2.1.4+1'
+  json_class: '^2.1.5+1'
   json_path: '^0.4.2'
-  json_schema2: '^2.0.2+21'
+  json_schema2: '^2.0.3+1'
   latlong2: '^0.8.1'
-  logging: '^1.1.0'
+  logging: '^1.1.1'
   meta: '^1.7.0'
   mime: '^1.0.4'
-  rest_client: '^2.2.0+8'
+  rest_client: '^2.2.1+1'
   shelf: '^1.4.0'
-  template_expressions: '^2.2.0+2'
+  template_expressions: '^2.2.1+1'
   uuid: '^3.0.7'
   x509: '^0.2.3'
-  yaon: '^1.0.1+9'
+  yaon: '^1.0.2'
 
-dev_dependencies:
+dev_dependencies: 
   args: '^2.3.2'
   build_runner: '^2.3.3'
   dependency_validator: '^3.2.2'
   test: '^1.22.2'
   test_process: '^2.0.3'
 
-false_secrets:
+false_secrets: 
   - 'example/server/assets/keys/privateKey.pem'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_class`: 2.1.4+1 --> 2.1.5+1
  * `json_schema2`: 2.0.2+21 --> 2.0.3+1
  * `logging`: 1.1.0 --> 1.1.1
  * `rest_client`: 2.2.0+8 --> 2.2.1+1
  * `template_expressions`: 2.2.0+2 --> 2.2.1+1
  * `yaon`: 1.0.1+9 --> 1.0.2


Analysis Successful


dependencies:
  * `rest_client`: 2.2.0+8 --> 2.2.1+1


Analysis Successful


