### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.1+3] - February 14, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.1+2] - February 7, 2023
 
 * Automated dependency updates
@@ -76,6 +81,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/client/pubspec.yaml
+++ b/example/client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'client'
 description: 'A new Flutter project.'
 publish_to: 'none'
-version: '1.0.0+10'
+version: '1.0.0+11'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -9,8 +9,8 @@ environment:
 dependencies: 
   flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.0+1'
-  rest_client: '^2.2.1+2'
+  flutter_svg: '^2.0.1'
+  rest_client: '^2.2.1+3'
 
 dev_dependencies: 
   flutter_test: 

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,20 +1,20 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+5'
+version: '1.0.0+6'
 publish_to: 'none'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
-  args: '^2.3.2'
-  dynamic_service:
+dependencies: 
+  args: '^2.4.0'
+  dynamic_service: 
     path: '../../'
   shelf_cors_headers: '^0.1.4'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.3.3'
   dependency_validator: '^3.2.2'
   functions_framework_builder: '^0.4.7'
-  test: '^1.22.2'
+  test: '^1.23.1'
   test_process: '^2.0.3'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.1+2'
+version: '1.0.1+3'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -13,25 +13,25 @@ dependencies:
   http: '^0.13.5'
   intl: '^0.18.0'
   jose: '^0.3.3'
-  json_class: '^2.1.5+1'
+  json_class: '^2.1.5+2'
   json_path: '^0.4.2'
-  json_schema2: '^2.0.3+2'
+  json_schema2: '^2.0.3+3'
   latlong2: '^0.8.1'
   logging: '^1.1.1'
   meta: '^1.7.0'
   mime: '^1.0.4'
-  rest_client: '^2.2.1+2'
+  rest_client: '^2.2.1+3'
   shelf: '^1.4.0'
-  template_expressions: '^2.2.1+1'
+  template_expressions: '^2.2.1+2'
   uuid: '^3.0.7'
   x509: '^0.2.3'
-  yaon: '^1.0.2'
+  yaon: '^1.0.2+1'
 
 dev_dependencies: 
-  args: '^2.3.2'
+  args: '^2.4.0'
   build_runner: '^2.3.3'
   dependency_validator: '^3.2.2'
-  test: '^1.22.2'
+  test: '^1.23.1'
   test_process: '^2.0.3'
 
 false_secrets: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_class`: 2.1.5+1 --> 2.1.5+2
  * `json_schema2`: 2.0.3+2 --> 2.0.3+3
  * `rest_client`: 2.2.1+2 --> 2.2.1+3
  * `template_expressions`: 2.2.1+1 --> 2.2.1+2
  * `yaon`: 1.0.2 --> 1.0.2+1

dev_dependencies:
  * `args`: 2.3.2 --> 2.4.0
  * `test`: 1.22.2 --> 1.23.1


Analysis Successful


dependencies:
  * `flutter_svg`: 2.0.0+1 --> 2.0.1
  * `rest_client`: 2.2.1+2 --> 2.2.1+3


Analysis Successful


dependencies:
  * `args`: 2.3.2 --> 2.4.0

dev_dependencies:
  * `test`: 1.22.2 --> 1.23.1


Analysis Successful

