### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+6] - May 9, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.2+5] - May 2, 2023
 
 * Automated dependency updates
@@ -131,6 +136,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,13 +1,13 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+8'
+version: '1.0.0+9'
 publish_to: 'none'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
 
 dependencies: 
-  args: '^2.4.0'
+  args: '^2.4.1'
   dynamic_service: 
     path: '../../'
   shelf_cors_headers: '^0.1.4'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.2+5'
+version: '1.0.2+6'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
+dependencies: 
   collection: '^1.16.0'
   crypto: '^3.0.1'
   encrypt: '^5.0.1'
@@ -15,29 +15,29 @@ dependencies:
   jose: '^0.3.3'
   json_class: '^2.2.1+3'
   json_path: '^0.5.2'
-  json_schema2: '^2.0.4+4'
+  json_schema2: '^2.0.4+5'
   latlong2: '^0.8.1'
   logging: '^1.1.1'
   meta: '^1.8.0'
   mime: '^1.0.4'
   rest_client: '^2.2.1+11'
-  shelf: '^1.4.0'
-  template_expressions: '^3.0.0+5'
+  shelf: '^1.4.1'
+  template_expressions: '^3.0.2+1'
   uuid: '^3.0.7'
   x509: '^0.2.3'
-  yaon: '^1.1.0+3'
+  yaon: '^1.1.0+4'
 
-dev_dependencies:
-  args: '^2.4.0'
+dev_dependencies: 
+  args: '^2.4.1'
   build_runner: '^2.3.3'
   dependency_validator: '^3.2.2'
   test: '^1.24.2'
   test_process: '^2.0.3'
 
-false_secrets:
+false_secrets: 
   - 'example/server/assets/keys/privateKey.pem'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_schema2`: 2.0.4+4 --> 2.0.4+5
  * `shelf`: 1.4.0 --> 1.4.1
  * `template_expressions`: 3.0.0+5 --> 3.0.2+1
  * `yaon`: 1.1.0+3 --> 1.1.0+4

dev_dependencies:
  * `args`: 2.4.0 --> 2.4.1


Analysis Successful



dependencies:
  * `args`: 2.4.0 --> 2.4.1


Analysis Successful

