### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+7] - May 16, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.2+6] - May 9, 2023
 
 * Automated dependency updates
@@ -136,6 +141,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+9'
+version: '1.0.0+10'
 publish_to: 'none'
 
 environment: 
@@ -10,10 +10,10 @@ dependencies:
   args: '^2.4.1'
   dynamic_service: 
     path: '../../'
-  shelf_cors_headers: '^0.1.4'
+  shelf_cors_headers: '^0.1.5'
 
 dev_dependencies: 
-  build_runner: '^2.3.3'
+  build_runner: '^2.4.4'
   dependency_validator: '^3.2.2'
   functions_framework_builder: '^0.4.7'
   test: '^1.24.2'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.2+6'
+version: '1.0.2+7'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -25,11 +25,11 @@ dependencies:
   template_expressions: '^3.0.2+1'
   uuid: '^3.0.7'
   x509: '^0.2.3'
-  yaon: '^1.1.0+4'
+  yaon: '^1.1.1'
 
 dev_dependencies: 
   args: '^2.4.1'
-  build_runner: '^2.3.3'
+  build_runner: '^2.4.4'
   dependency_validator: '^3.2.2'
   test: '^1.24.2'
   test_process: '^2.0.3'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `yaon`: 1.1.0+4 --> 1.1.1

dev_dependencies:
  * `build_runner`: 2.3.3 --> 2.4.4


Analysis Successful



dependencies:
  * `shelf_cors_headers`: 0.1.4 --> 0.1.5

dev_dependencies:
  * `build_runner`: 2.3.3 --> 2.4.4


Analysis Successful

