### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+8] - May 30, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.2+7] - May 16, 2023
 
 * Automated dependency updates
@@ -141,6 +146,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/client/pubspec.yaml
+++ b/example/client/pubspec.yaml
@@ -1,21 +1,21 @@
 name: 'client'
 description: 'A new Flutter project.'
 publish_to: 'none'
-version: '1.0.0+21'
+version: '1.0.0+22'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  flutter:
+dependencies: 
+  flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.5'
+  flutter_svg: '^2.0.6'
   rest_client: '^2.2.1+11'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
   flutter_lints: '^2.0.1'
 
-flutter:
+flutter: 
   uses-material-design: true

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,20 +1,20 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+10'
+version: '1.0.0+11'
 publish_to: 'none'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
+dependencies: 
   args: '^2.4.1'
-  dynamic_service:
+  dynamic_service: 
     path: '../../'
   shelf_cors_headers: '^0.1.5'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.4.4'
   dependency_validator: '^3.2.2'
   functions_framework_builder: '^0.4.7'
-  test: '^1.24.2'
-  test_process: '^2.0.3'
+  test: '^1.24.3'
+  test_process: '^2.1.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,43 +1,43 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.2+7'
+version: '1.0.2+8'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
+dependencies: 
   collection: '^1.16.0'
   crypto: '^3.0.1'
   encrypt: '^5.0.1'
-  http: '^0.13.6'
+  http: '^1.0.0'
   intl: '^0.18.1'
   jose: '^0.3.3'
   json_class: '^2.2.1+3'
-  json_path: '^0.5.2'
-  json_schema2: '^2.0.4+5'
-  latlong2: '^0.8.1'
-  logging: '^1.1.1'
+  json_path: '^0.6.0'
+  json_schema2: '^2.0.4+8'
+  latlong2: '^0.9.0'
+  logging: '^1.2.0'
   meta: '^1.9.0'
   mime: '^1.0.4'
   rest_client: '^2.2.1+11'
   shelf: '^1.4.1'
-  template_expressions: '^3.0.2+1'
+  template_expressions: '^3.0.4+1'
   uuid: '^3.0.7'
   x509: '^0.2.3'
   yaon: '^1.1.1'
 
-dev_dependencies:
+dev_dependencies: 
   args: '^2.4.1'
   build_runner: '^2.4.4'
   dependency_validator: '^3.2.2'
-  test: '^1.24.2'
-  test_process: '^2.0.3'
+  test: '^1.24.3'
+  test_process: '^2.1.0'
 
-false_secrets:
+false_secrets: 
   - 'example/server/assets/keys/privateKey.pem'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `http`: 0.13.6 --> 1.0.0
  * `json_path`: 0.5.2 --> 0.6.0
  * `json_schema2`: 2.0.4+5 --> 2.0.4+8
  * `latlong2`: 0.8.1 --> 0.9.0
  * `logging`: 1.1.1 --> 1.2.0
  * `template_expressions`: 3.0.2+1 --> 3.0.4+1

dev_dependencies:
  * `test`: 1.24.2 --> 1.24.3
  * `test_process`: 2.0.3 --> 2.1.0


Error!!!
```
Resolving dependencies...


Because rest_client >=2.2.1+11 depends on http ^0.13.6 and dynamic_service depends on http ^1.0.0, rest_client >=2.2.1+11 is forbidden.
So, because dynamic_service depends on rest_client ^2.2.1+11, version solving failed.

```


dependencies:
  * `flutter_svg`: 2.0.5 --> 2.0.6


Analysis Successful


dev_dependencies:
  * `test`: 1.24.2 --> 1.24.3
  * `test_process`: 2.0.3 --> 2.1.0


Error!!!
```
Resolving dependencies...


Because rest_client >=2.2.1+11 depends on http ^0.13.6 and every version of dynamic_service from path depends on http ^1.0.0, rest_client >=2.2.1+11 is incompatible with dynamic_service from path.
So, because dynamic_service_example depends on dynamic_service from path which depends on rest_client ^2.2.1+11, version solving failed.

```

