### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+14] - January 16, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.2+13] - November 28, 2023
 
 * Automated dependency updates
@@ -171,6 +176,7 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
+
 
 
 

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,6 +1,6 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+15'
+version: '1.0.0+16'
 publish_to: 'none'
 
 environment: 
@@ -13,8 +13,8 @@ dependencies:
   shelf_cors_headers: '^0.1.5'
 
 dev_dependencies: 
-  build_runner: '^2.4.7'
+  build_runner: '^2.4.8'
   dependency_validator: '^3.2.3'
   functions_framework_builder: '^0.4.10'
-  test: '^1.24.9'
+  test: '^1.25.1'
   test_process: '^2.1.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.2+13'
+version: '1.0.2+14'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -11,10 +11,10 @@ dependencies:
   crypto: '^3.0.1'
   encrypt: '^5.0.3'
   http: '^1.1.2'
-  intl: '^0.18.1'
+  intl: '^0.19.0'
   jose: '^0.3.4'
-  json_class: '^3.0.0+8'
-  json_path: '^0.6.6'
+  json_class: '^3.0.0+11'
+  json_path: '^0.7.0'
   json_schema2: '^5.1.3'
   latlong2: '^0.9.0'
   logging: '^1.2.0'
@@ -22,16 +22,16 @@ dependencies:
   mime: '^1.0.4'
   rest_client: '^2.4.0'
   shelf: '^1.4.1'
-  template_expressions: '^3.1.5'
-  uuid: '^4.2.1'
-  x509: '^0.2.4'
-  yaon: '^1.1.4'
+  template_expressions: '^3.1.5+3'
+  uuid: '^4.3.3'
+  x509: '^0.2.4+2'
+  yaon: '^1.1.4+2'
 
 dev_dependencies: 
   args: '^2.4.2'
   dependency_validator: '^3.2.3'
   flutter_lints: '^3.0.1'
-  test: '^1.24.9'
+  test: '^1.25.1'
   test_process: '^2.1.0'
 
 false_secrets: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `intl`: 0.18.1 --> 0.19.0
  * `json_class`: 3.0.0+8 --> 3.0.0+11
  * `json_path`: 0.6.6 --> 0.7.0
  * `template_expressions`: 3.1.5 --> 3.1.5+3
  * `uuid`: 4.2.1 --> 4.3.3
  * `x509`: 0.2.4 --> 0.2.4+2
  * `yaon`: 1.1.4 --> 1.1.4+2

dev_dependencies:
  * `test`: 1.24.9 --> 1.25.1


Error!!!
```
Resolving dependencies...


Because template_expressions >=3.1.2 depends on json_path ^0.6.3 and dynamic_service depends on json_path ^0.7.0, template_expressions >=3.1.2 is forbidden.
So, because dynamic_service depends on template_expressions ^3.1.5+3, version solving failed.

```



dev_dependencies:
  * `build_runner`: 2.4.7 --> 2.4.8
  * `test`: 1.24.9 --> 1.25.1


Error!!!
```
Resolving dependencies...


Because template_expressions >=3.1.2 depends on json_path ^0.6.3 and every version of dynamic_service from path depends on json_path ^0.7.0, template_expressions >=3.1.2 is incompatible with dynamic_service from path.
So, because dynamic_service_example depends on dynamic_service from path which depends on template_expressions ^3.1.5+3, version solving failed.

```

