### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+14] - November 19, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.2+13] - November 28, 2023
 
 * Automated dependency updates
@@ -171,34 +176,3 @@
 ## [0.9.0] - April 16th, 2022
 
 * Beta release
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/example/client/pubspec.yaml
+++ b/example/client/pubspec.yaml
@@ -1,21 +1,21 @@
 name: 'client'
 description: 'A new Flutter project.'
 publish_to: 'none'
-version: '1.0.0+25'
+version: '1.0.0+26'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
-  flutter: 
+dependencies:
+  flutter:
     sdk: 'flutter'
-  flutter_svg: '^2.0.9'
+  flutter_svg: '^2.0.14'
   rest_client: '^2.4.0'
 
-dev_dependencies: 
-  flutter_test: 
+dev_dependencies:
+  flutter_test:
     sdk: 'flutter'
-  flutter_lints: '^3.0.1'
+  flutter_lints: '^5.0.0'
 
-flutter: 
+flutter:
   uses-material-design: true

--- a/example/server/pubspec.yaml
+++ b/example/server/pubspec.yaml
@@ -1,20 +1,20 @@
 name: 'dynamic_service_example'
 description: 'An example of the Dart based dynamic_service'
-version: '1.0.0+15'
+version: '1.0.0+16'
 publish_to: 'none'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
-  args: '^2.4.2'
-  dynamic_service: 
+dependencies:
+  args: '^2.6.0'
+  dynamic_service:
     path: '../../'
   shelf_cors_headers: '^0.1.5'
 
-dev_dependencies: 
-  build_runner: '^2.4.7'
-  dependency_validator: '^3.2.3'
+dev_dependencies:
+  build_runner: '^2.4.13'
+  dependency_validator: '^4.1.1'
   functions_framework_builder: '^0.4.10'
-  test: '^1.24.9'
+  test: '^1.25.8'
   test_process: '^2.1.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,43 +1,43 @@
 name: 'dynamic_service'
 description: 'A Dart based service for handling dynamic requests and responses'
 homepage: 'https://github.com/peiffer-innovations/dynamic_service'
-version: '1.0.2+13'
+version: '1.0.2+14'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies: 
+dependencies:
   collection: '^1.16.0'
   crypto: '^3.0.1'
   encrypt: '^5.0.3'
-  http: '^1.1.2'
-  intl: '^0.18.1'
+  http: '^1.2.2'
+  intl: '^0.20.0'
   jose: '^0.3.4'
-  json_class: '^3.0.0+8'
-  json_path: '^0.6.6'
+  json_class: '^3.0.0+16'
+  json_path: '^0.7.4'
   json_schema2: '^5.1.3'
-  latlong2: '^0.9.0'
-  logging: '^1.2.0'
+  latlong2: '^0.9.1'
+  logging: '^1.3.0'
   meta: '^1.9.1'
-  mime: '^1.0.4'
+  mime: '^2.0.0'
   rest_client: '^2.4.0'
-  shelf: '^1.4.1'
-  template_expressions: '^3.1.5'
-  uuid: '^4.2.1'
-  x509: '^0.2.4'
-  yaon: '^1.1.4'
+  shelf: '^1.4.2'
+  template_expressions: '^3.3.0+2'
+  uuid: '^4.5.1'
+  x509: '^0.2.4+3'
+  yaon: '^1.1.4+10'
 
-dev_dependencies: 
-  args: '^2.4.2'
-  dependency_validator: '^3.2.3'
-  flutter_lints: '^3.0.1'
-  test: '^1.24.9'
+dev_dependencies:
+  args: '^2.6.0'
+  dependency_validator: '^4.1.1'
+  flutter_lints: '^5.0.0'
+  test: '^1.25.8'
   test_process: '^2.1.0'
 
-false_secrets: 
+false_secrets:
   - 'example/server/assets/keys/privateKey.pem'
 
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `http`: 1.1.2 --> 1.2.2
  * `intl`: 0.18.1 --> 0.20.0
  * `json_class`: 3.0.0+8 --> 3.0.0+16
  * `json_path`: 0.6.6 --> 0.7.4
  * `latlong2`: 0.9.0 --> 0.9.1
  * `logging`: 1.2.0 --> 1.3.0
  * `mime`: 1.0.4 --> 2.0.0
  * `shelf`: 1.4.1 --> 1.4.2
  * `template_expressions`: 3.1.5 --> 3.3.0+2
  * `uuid`: 4.2.1 --> 4.5.1
  * `x509`: 0.2.4 --> 0.2.4+3
  * `yaon`: 1.1.4 --> 1.1.4+10

dev_dependencies:
  * `args`: 2.4.2 --> 2.6.0
  * `dependency_validator`: 3.2.3 --> 4.1.1
  * `flutter_lints`: 3.0.1 --> 5.0.0
  * `test`: 1.24.9 --> 1.25.8


Error!!!
```
Resolving dependencies...


Because template_expressions >=3.1.5+1 depends on intl ^0.19.0 and dynamic_service depends on intl ^0.20.0, template_expressions >=3.1.5+1 is forbidden.
So, because dynamic_service depends on template_expressions ^3.3.0+2, version solving failed.

```


dependencies:
  * `flutter_svg`: 2.0.9 --> 2.0.14

dev_dependencies:
  * `flutter_lints`: 3.0.1 --> 5.0.0


Analysis Successful


dependencies:
  * `args`: 2.4.2 --> 2.6.0

dev_dependencies:
  * `build_runner`: 2.4.7 --> 2.4.13
  * `dependency_validator`: 3.2.3 --> 4.1.1
  * `test`: 1.24.9 --> 1.25.8


Error!!!
```
Resolving dependencies...


Because template_expressions >=3.1.5+1 depends on intl ^0.19.0 and every version of dynamic_service from path depends on intl ^0.20.0, template_expressions >=3.1.5+1 is incompatible with dynamic_service from path.
So, because dynamic_service_example depends on dynamic_service from path which depends on template_expressions ^3.3.0+2, version solving failed.

```

